### PR TITLE
Fixed inheritance issue on referee.py and takeaway_referee.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.png
+*.tbz
+*.svg
+**/.ipynb_checkpoints
+**/__pycache__

--- a/jupyter_notes/toothpick_takeaway.ipynb
+++ b/jupyter_notes/toothpick_takeaway.ipynb
@@ -539,6 +539,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Theorem 1\n",
+    "#### $P_1$  will win $\\iff N \\mod 3 \\ne 0$ <br>\n",
+    "\n",
+    "\n",
+    "_Proof_: Let $N$ be the number of toothpicks left on the table. <br>\n",
+    "\n",
+    "Base Cases: $N = 1, 2, 3$ <br>\n",
+    "1. $N = 0$: So $N \\mod 3 = 0$. If $P_1$ draws 1,  $N = 2$ and $P_2$ will win. If $P_1$ draws 2,  $N = 1$ and $P_2$ will win. <br>\n",
+    "2. $N = 1$: So $N \\mod 3 = 1$. $P_1$ draws 1, so $P_1$ wins. <br>\n",
+    "3. $N = 2$: So $N \\mod 3 = 2$. $P_1$ draws 2, so $P_1$ wins. <br>\n",
+    "\n",
+    "Inductive Hypothesis: Assume $P_1$ will win if $K \\mod 3 \\ne 0$ for some $K \\in \\mathbb{Z}^{+}$ <br>\n",
+    "1. Consider $K+1$. So $K \\mod 3 = 1$."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Optimal Strategies\n",
     "Player 1's primary goal should be to force the game into a state where the number of toothpicks left on the table is a multiple of 3 _and_ it is Player 2's turn. We know this is a win condition for Player 1 by Theorem 1. Once this criteria is met, Player 1 will want to do the opposite of whatever Player 2 does. For instance, if the number of toothpicks on the is a multiple of 3 and Player 2 draws a single toothpick, Player 1 will want to draw two toothpicks, causing the number of toothpicks on the table to remain a multiple of 3 while on Player 2's turn. Essentially, Player 1 wants each game cycle (that is, both players take a turn) to decrease the number of toothpicks on the table by 3."
    ]

--- a/simple_games/toothpick_takeaway/takeaway_referee.py
+++ b/simple_games/toothpick_takeaway/takeaway_referee.py
@@ -2,9 +2,12 @@
 # This class models a Referee for the toothpick takeaway game.
 #
 # Authors: Daniel Hammer, Nihcolas O'Kelley, Andrew Shelton
-
 #
 ##
+
+import sys
+sys.path.append("../generic_classes")
+from referee import Referee
 
 class takeaway_referee(Referee):
     """The toothpick takeaway referee subclass."""


### PR DESCRIPTION
We have to do the following for each game-specific class:

import sys
sys.path.append("../generic_classes")
from [filename] import [class name]